### PR TITLE
Sync: implicitly nullable parameters fix

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -4,7 +4,7 @@
 # patreon: # Replace with a single Patreon username
 # open_collective: # Replace with a single Open Collective username
 # ko_fi: # Replace with a single Ko-fi username
-tidelift: "packagist/paquettg/php-html-parser"
+tidelift: "packagist/igor-krein/php-html-parser"
 # community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 # liberapay: # Replace with a single Liberapay username
 # issuehunt: # Replace with a single IssueHunt username

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 PHP Html Parser
 ==========================
+This is a fork of the original [PHP Html Parser] with only updated dependencies. The original package is no longer maintained.
 
 [![Build Status](https://travis-ci.org/paquettg/php-html-parser.png)](https://travis-ci.org/paquettg/php-html-parser)
 [![Coverage Status](https://coveralls.io/repos/paquettg/php-html-parser/badge.png)](https://coveralls.io/r/paquettg/php-html-parser)
@@ -13,10 +14,10 @@ Install
 Install the latest version using composer.
 
 ```bash
-$ composer require paquettg/php-html-parser
+$ composer require igor-krein/php-html-parser
 ```
 
-This package can be found on [packagist](https://packagist.org/packages/paquettg/php-html-parser) and is best loaded using [composer](http://getcomposer.org/). We support PHP 7.2, 7.3, and 7.4. Also, it is supposed to be PHP 8.4 compatible.
+This package can be found on [packagist](https://packagist.org/packages/igor-krein/php-html-parser) and is best loaded using [composer](http://getcomposer.org/). We support PHP 7.2, 7.3, and 7.4. Also, it is supposed to be PHP 8.4 compatible.
 
 Basic Usage
 -----

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install the latest version using composer.
 $ composer require paquettg/php-html-parser
 ```
 
-This package can be found on [packagist](https://packagist.org/packages/paquettg/php-html-parser) and is best loaded using [composer](http://getcomposer.org/). We support php 7.2, 7.3, and 7.4.
+This package can be found on [packagist](https://packagist.org/packages/paquettg/php-html-parser) and is best loaded using [composer](http://getcomposer.org/). We support PHP 7.2, 7.3, and 7.4. Also, it is supposed to be PHP 8.4 compatible.
 
 Basic Usage
 -----

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "paquettg/php-html-parser",
+    "name": "igor-krein/php-html-parser",
     "type": "library",
     "description": "An HTML DOM parser. It allows you to manipulate HTML. Find tags on an HTML page with selectors just like jQuery.",
     "keywords": ["html", "dom", "parser"],
-    "homepage": "https://github.com/paquettg/php-html-parser",
+    "homepage": "https://github.com/igor-krein/php-html-parser",
     "license": "MIT",
     "authors": [
         {

--- a/src/PHPHtmlParser/Contracts/DomInterface.php
+++ b/src/PHPHtmlParser/Contracts/DomInterface.php
@@ -19,5 +19,5 @@ interface DomInterface
 
     public function setOptions(Options $options): Dom;
 
-    public function find(string $selector, int $nth = null);
+    public function find(string $selector, ?int $nth = null);
 }

--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -180,7 +180,7 @@ class Dom implements DomInterface
      *
      * @return mixed|Collection|null
      */
-    public function find(string $selector, int $nth = null)
+    public function find(string $selector, ?int $nth = null)
     {
         $this->isLoaded();
 

--- a/src/PHPHtmlParser/StaticDom.php
+++ b/src/PHPHtmlParser/StaticDom.php
@@ -81,7 +81,7 @@ final class StaticDom
      * @throws StrictException
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public static function loadFromUrl(string $url, ?Options $options = null, ClientInterface $client = null, RequestInterface $request = null): Dom
+    public static function loadFromUrl(string $url, ?Options $options = null, ?ClientInterface $client = null, ?RequestInterface $request = null): Dom
     {
         $dom = new Dom();
         self::$dom = $dom;


### PR DESCRIPTION
In PHP 8.4, implicitly nullable parameters (like _int $param = null_ instead of **_?_**_int $param = null_) are deprecated. The fix should solve this issue.